### PR TITLE
Specifiy the project's language.

### DIFF
--- a/CMake/CMakeLists.txt
+++ b/CMake/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake build control file for Library Status
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 2.8.12)
 
 project("LibraryStatus" CXX)
 

--- a/CMake/CMakeLists.txt
+++ b/CMake/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.0)
 
-project("LibraryStatus")
+project("LibraryStatus" CXX)
 
 #
 # Compiler settings - special settings for known compilers


### PR DESCRIPTION
If the language is not explicitly specified, the default choice is C and C++.
But apparently, if one decided to change both compilers n the cmake command line,
only the first is considered, which can cause some (small) trouble.

Also, it seems that the cmake version constraint can be relaxed.
